### PR TITLE
docs(http): fix attributes not being marked as attributes

### DIFF
--- a/nextcore/http/client.py
+++ b/nextcore/http/client.py
@@ -141,8 +141,6 @@ class HTTPClient:
             .. tab:: Windows
 
                 This can be turned on by going to ``Settings -> Time & language -> Date & time`` and turning on ``Set time automatically``.
-
-
     timeout:
         The default request timeout in seconds.
     default_headers:


### PR DESCRIPTION
This fixes the issue of HTTPClient attributes being broken.
![image](https://user-images.githubusercontent.com/35035079/171991886-d74026e3-83b1-444b-addf-2e632df549c5.png)
