### PR TITLE
fix(gateway): remove dollar in identify props

### DIFF
--- a/nextcore/gateway/shard.py
+++ b/nextcore/gateway/shard.py
@@ -588,9 +588,9 @@ class Shard:
                 "token": self.token,
                 "intents": self.intents,
                 "properties": {
-                    "$os": platform,
-                    "$browser": self.library_name,
-                    "$device": self.library_name,
+                    "os": platform,
+                    "browser": self.library_name,
+                    "device": self.library_name,
                 },
                 "compress": True,
                 "shard": [self.shard_id, self.shard_count],


### PR DESCRIPTION
Remove `$` from `os`, `browser`, `device` in `payload.d.properties` for `IDENTIFY`, as changed in discord/discord-api-docs#5067

fixes #54