### PR TITLE
fix: explicit None returns in class `__init__`s

### DIFF
--- a/nextcore/gateway/times_per.py
+++ b/nextcore/gateway/times_per.py
@@ -67,7 +67,7 @@ class TimesPer:
 
     __slots__ = ("total", "remaining", "per", "_reset_at", "_lock")
 
-    def __init__(self, total: int, per: float):
+    def __init__(self, total: int, per: float) -> None:
         self.total: int = total
         self.remaining: int = total
         self.per: float = per

--- a/nextcore/http/authentication/base.py
+++ b/nextcore/http/authentication/base.py
@@ -45,7 +45,7 @@ class BaseAuthentication:
 
     __slots__ = ("prefix", "token", "rate_limit_key")
 
-    def __init__(self, prefix: str, token: str):
+    def __init__(self, prefix: str, token: str) -> None:
         self.prefix: str = prefix
         self.token: str = token
         self.rate_limit_key: str = token

--- a/nextcore/http/authentication/bearer.py
+++ b/nextcore/http/authentication/bearer.py
@@ -49,7 +49,7 @@ class BearerAuthentication(BaseAuthentication):
 
     __slots__: tuple[str, ...] = ()
 
-    def __init__(self, token: str):
+    def __init__(self, token: str) -> None:
         self.prefix: Literal["Bearer"] = "Bearer"
         self.token: str = token
         self.rate_limit_key: str = f"{self.prefix} {self.token}"

--- a/nextcore/http/authentication/bot.py
+++ b/nextcore/http/authentication/bot.py
@@ -49,7 +49,7 @@ class BotAuthentication(BaseAuthentication):
 
     __slots__: tuple[str, ...] = ()
 
-    def __init__(self, token: str):
+    def __init__(self, token: str) -> None:
         self.prefix: Literal["Bot"] = "Bot"
         self.token: str = token
         self.rate_limit_key: str = f"{self.prefix} {self.token}"

--- a/nextcore/http/bucket.py
+++ b/nextcore/http/bucket.py
@@ -62,7 +62,7 @@ class Bucket:
         "__weakref__",
     )
 
-    def __init__(self, metadata: BucketMetadata):
+    def __init__(self, metadata: BucketMetadata) -> None:
         self.metadata: BucketMetadata = metadata
         self._remaining: int | None = self.metadata.limit
         self._reserved: list[RequestSession] = []  # Requests currently being processed

--- a/nextcore/http/bucket_metadata.py
+++ b/nextcore/http/bucket_metadata.py
@@ -55,6 +55,6 @@ class BucketMetadata:
 
     __slots__ = ("limit", "unlimited")
 
-    def __init__(self, limit: int | None = None, *, unlimited: bool = False):
+    def __init__(self, limit: int | None = None, *, unlimited: bool = False) -> None:
         self.limit: int | None = limit
         self.unlimited: bool = unlimited

--- a/nextcore/http/client.py
+++ b/nextcore/http/client.py
@@ -174,7 +174,7 @@ class HTTPClient:
         trust_local_time: bool = True,
         timeout: float = 60,
         max_ratelimit_retries: int = 10,
-    ):
+    ) -> None:
         self.trust_local_time: bool = trust_local_time
         self.timeout: float = timeout
         self.default_headers: dict[str, str] = {

--- a/nextcore/http/file.py
+++ b/nextcore/http/file.py
@@ -60,6 +60,6 @@ class File:
 
     __slots__ = ("name", "contents")
 
-    def __init__(self, name: str, contents: Contents):
+    def __init__(self, name: str, contents: Contents) -> None:
         self.name: Final[str] = name
         self.contents: Contents = contents

--- a/nextcore/http/global_rate_limiter/priority_request_container.py
+++ b/nextcore/http/global_rate_limiter/priority_request_container.py
@@ -50,7 +50,7 @@ class PriorityRequestContainer:
 
     __slots__: tuple[str, ...] = ("priority", "future")
 
-    def __init__(self, priority: int, future: Future[None]):
+    def __init__(self, priority: int, future: Future[None]) -> None:
         self.priority: int = priority
         self.future: Future[None] = future
 

--- a/nextcore/http/request_session.py
+++ b/nextcore/http/request_session.py
@@ -52,6 +52,6 @@ class RequestSession:
 
     __slots__: Final[tuple[str, ...]] = ("pending_future", "unlimited")
 
-    def __init__(self, unlimited: bool):
+    def __init__(self, unlimited: bool) -> None:
         self.pending_future: Future[None] = Future()
         self.unlimited: bool = unlimited


### PR DESCRIPTION
Explicitly return `None` in class `__init__`s to add clarity on return types as well as consistency.

fixes #43
