### PR TITLE
Add py.typed file

### DIFF
--- a/nextcore/py.typed
+++ b/nextcore/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# This marks that we use inline typings for type checkers


### PR DESCRIPTION
This fixes a issue where type checkers like MyPy will not find the typings.

See [PEP 561](https://peps.python.org/pep-0561/)