### PR TITLE
Faster shard reconnection

### DIFF
--- a/nextcore/gateway/shard.py
+++ b/nextcore/gateway/shard.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
         UpdatePresenceData,
         UpdateVoiceStateCommand,
         UpdateVoiceStateData,
+        UpdatePresenceCommand
     )
     from discord_typings.gateway import ReadyData, UpdatePresenceData
 


### PR DESCRIPTION
This works by waiting until it has connected to the gateway before closing the previous instance.

This fixes #86 