### PR TITLE
Add opengraph info

### DIFF
--- a/docs/common.rst
+++ b/docs/common.rst
@@ -1,5 +1,7 @@
 .. currentmodule:: nextcore.common
 
+:og:title: Nextcore common documentation
+:og:description: Documentation for the common part of nextcore. This is for things that does not neccesarily fit into any specific module in nextcore.
 
 Common
 ======

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,10 @@ intersphinx_mapping = {
     "towncrier": ("https://towncrier.readthedocs.io/en/stable", None),
 }
 
+# Opengraph
+ogp_image = "/_static/logo.svg"
+ogp_site_name = "Nextcore Documentation"
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/contributing/getting_started.rst
+++ b/docs/contributing/getting_started.rst
@@ -1,3 +1,6 @@
+:og:title: Nextcore contribution guide
+:og:description: Info about getting started helping out with the nextcore project!
+
 Contributing
 =============
 

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,5 +1,7 @@
 .. currentmodule:: nextcore
 
+:og:title: Nextcore event reference
+:og:description: This gives you examples for some Dispatcher events.
 
 Events
 ======

--- a/docs/gateway.rst
+++ b/docs/gateway.rst
@@ -1,5 +1,8 @@
 .. currentmodule:: nextcore.gateway
 
+:og:title: Nextcore gateway documentation
+:og:description: Documentation for the gateway part of nextcore. This is for things like connecting as a bot and receiving messages.
+
 Gateway
 =======
 

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -1,5 +1,8 @@
 .. currentmodule:: nextcore.http
 
+:og:title: Nextcore HTTP documentation
+:og:description: Documentation for the HTTP part of nextcore. This is for things like making HTTP requests and HTTP specific rate limiting.
+
 HTTP
 ====
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+:og:description: A super fast low level Discord library for full control.
+
 Welcome to Nextcore's documentation!
 ====================================
 


### PR DESCRIPTION
This makes the docs easier to look at on Discord & google.

Not too sure if I am abusing the image property, however I kind of want the nextcore/nextsnake logo somewhere on the embed.

twitter:image might be the right one? Not sure

Fixes #181 