### PR TITLE
Automatic safeguard disconnect wrongly firing on low-latency internet connections

### DIFF
--- a/newsfragments/251.bugfix
+++ b/newsfragments/251.bugfix
@@ -1,0 +1,1 @@
+Stop reconnect-loop on low-latency network connections


### PR DESCRIPTION
This was caused by a race condition where the HELLO event was received before the temporary listener was added.

This makes it a event so anybody can hook into it in case they want to, and cleans up the code a bit.

Fixes #251