### PR TITLE
fix api version param name

### DIFF
--- a/nextcore/http/client/client.py
+++ b/nextcore/http/client/client.py
@@ -429,7 +429,7 @@ class HTTPClient(BaseHTTPClient):
         # These have different behaviour when not provided and set to None.
         # This only adds them if they are provided (not Undefined)
         if version is not UNDEFINED:
-            params["version"] = version
+            params["v"] = version
         if encoding is not UNDEFINED:
             params["encoding"] = encoding
         if compress is not UNDEFINED:


### PR DESCRIPTION
As stated [here](https://discord.com/developers/docs/topics/gateway#connecting-gateway-url-query-string-params) API version parameter name should be "v".

Without the fix some events like MESSAGE_CREATE inside a discord thread are missing.