### PR TITLE
Bump `discord-typings` version so projects can make use of the newer versions without version conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nextcore"
-version = "2.0.2"
+version = "2.0.3"
 description = "A low level Discord API wrapper"
 authors = ["tag-epic"]
 license = "MIT"
@@ -38,7 +38,7 @@ types-frozendict = "^2.0.6" # Could we extend the version requirement
 typing-extensions = "^4.1.1" # Same as above
 orjson = {version = "^3.6.8", optional = true}
 types-orjson = {version = "^3.6.2", optional = true}
-discord-typings = "^0.5.0"
+discord-typings = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 Sphinx = "^5.0.0"


### PR DESCRIPTION
Right now projects making use of this library cannot depend on the newer versions of `discord-typings` as the requirement in nextcore (`discord-typings<0.6.0,>=0.5.0`) is causing pip to refuse to install later versions.

The easiest solution is to bump the `discord-typings` version in nextcore.

```
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/goldy/Documents/projects/goldy/python/example_bot
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: nextcore>=2.0.2 in /home/goldy/.local/lib/python3.11/site-packages (from example_bot==0.1.0) (2.0.2)
Requirement already satisfied: attrs>=23.2.0 in /home/goldy/.local/lib/python3.11/site-packages (from example_bot==0.1.0) (24.2.0)
Requirement already satisfied: aiofiles>=24.1.0 in /home/goldy/.local/lib/python3.11/site-packages (from example_bot==0.1.0) (24.1.0)
Collecting discord-typings>=0.9.0 (from example_bot==0.1.0)
  Using cached discord_typings-0.9.0-py3-none-any.whl.metadata (6.1 kB)
Requirement already satisfied: typing_extensions<5,>=4.3 in /home/goldy/.local/lib/python3.11/site-packages (from discord-typings>=0.9.0->example_bot==0.1.0) (4.12.2)
Requirement already satisfied: aiohttp<4.0.0,>=3.6.0 in /home/goldy/.local/lib/python3.11/site-packages (from nextcore>=2.0.2->example_bot==0.1.0) (3.10.3)
INFO: pip is looking at multiple versions of nextcore to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install example_bot==0.1.0 and nextcore==2.0.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    example_bot 0.1.0 depends on discord-typings>=0.9.0
    nextcore 2.0.2 depends on discord-typings<0.6.0 and >=0.5.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```